### PR TITLE
Add starter Android Greek Learner app (Compose + Material3)

### DIFF
--- a/android-app/app/build.gradle.kts
+++ b/android-app/app/build.gradle.kts
@@ -1,0 +1,49 @@
+plugins {
+    alias(libs.plugins.android.application)
+    alias(libs.plugins.jetbrains.kotlin.android)
+}
+
+android {
+    namespace = "com.custories.greeklearner"
+    compileSdk = 34
+
+    defaultConfig {
+        applicationId = "com.custories.greeklearner"
+        minSdk = 26
+        targetSdk = 34
+        versionCode = 1
+        versionName = "1.0"
+    }
+
+    buildTypes {
+        release {
+            isMinifyEnabled = false
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro"
+            )
+        }
+    }
+
+    buildFeatures {
+        compose = true
+    }
+
+    composeOptions {
+        kotlinCompilerExtensionVersion = "1.5.15"
+    }
+
+    kotlinOptions {
+        jvmTarget = "17"
+    }
+}
+
+dependencies {
+    implementation(platform(libs.androidx.compose.bom))
+    implementation(libs.androidx.core.ktx)
+    implementation(libs.androidx.activity.compose)
+    implementation(libs.androidx.compose.ui)
+    implementation(libs.androidx.compose.material3)
+    implementation(libs.androidx.compose.ui.tooling.preview)
+    debugImplementation(libs.androidx.compose.ui.tooling)
+}

--- a/android-app/app/proguard-rules.pro
+++ b/android-app/app/proguard-rules.pro
@@ -1,0 +1,1 @@
+# Add project specific ProGuard rules here.

--- a/android-app/app/src/main/AndroidManifest.xml
+++ b/android-app/app/src/main/AndroidManifest.xml
@@ -1,0 +1,18 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <application
+        android:allowBackup="true"
+        android:label="Greek Learner"
+        android:icon="@mipmap/ic_launcher"
+        android:roundIcon="@mipmap/ic_launcher_round"
+        android:supportsRtl="true"
+        android:theme="@style/Theme.GreekLearner">
+        <activity
+            android:name=".MainActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/android-app/app/src/main/java/com/custories/greeklearner/MainActivity.kt
+++ b/android-app/app/src/main/java/com/custories/greeklearner/MainActivity.kt
@@ -1,0 +1,195 @@
+package com.custories.greeklearner
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+
+class MainActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            GreekLearnerTheme {
+                Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {
+                    GreekLearnerApp()
+                }
+            }
+        }
+    }
+}
+
+data class Lesson(
+    val title: String,
+    val greek: String,
+    val transliteration: String,
+    val meaning: String,
+    val tip: String
+)
+
+@Composable
+fun GreekLearnerApp() {
+    val lessons = remember {
+        listOf(
+            Lesson(
+                title = "Greetings",
+                greek = "Γειά σου",
+                transliteration = "Yah soo",
+                meaning = "Hello (informal)",
+                tip = "Use with friends and family."
+            ),
+            Lesson(
+                title = "Polite hello",
+                greek = "Καλημέρα",
+                transliteration = "Kah-lee-MEH-rah",
+                meaning = "Good morning",
+                tip = "Use before noon as a polite greeting."
+            ),
+            Lesson(
+                title = "Thank you",
+                greek = "Ευχαριστώ",
+                transliteration = "Ef-hah-ree-STOH",
+                meaning = "Thank you",
+                tip = "Say this anytime you want to show appreciation."
+            ),
+            Lesson(
+                title = "Ordering",
+                greek = "Θα ήθελα...",
+                transliteration = "Tha EE-the-la",
+                meaning = "I would like...",
+                tip = "Great starter phrase for cafés or shops."
+            )
+        )
+    }
+
+    var dailyGoal by remember { mutableStateOf(10) }
+    var minutesLogged by remember { mutableStateOf(3) }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background)
+            .padding(16.dp)
+    ) {
+        Text(
+            text = "Greek Learner",
+            style = MaterialTheme.typography.headlineMedium,
+            fontWeight = FontWeight.Bold
+        )
+        Text(
+            text = "Daily focus: ${"%d".format(minutesLogged)} / $dailyGoal minutes",
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.primary
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+        ProgressCard(minutesLogged = minutesLogged, dailyGoal = dailyGoal) {
+            if (minutesLogged < dailyGoal) {
+                minutesLogged += 1
+            }
+        }
+        Spacer(modifier = Modifier.height(20.dp))
+        Text(
+            text = "Today’s bite-size lessons",
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.SemiBold
+        )
+        Spacer(modifier = Modifier.height(12.dp))
+        LazyColumn(
+            contentPadding = PaddingValues(bottom = 16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            items(lessons) { lesson ->
+                LessonCard(lesson = lesson)
+            }
+        }
+    }
+}
+
+@Composable
+fun ProgressCard(minutesLogged: Int, dailyGoal: Int, onQuickPractice: () -> Unit) {
+    val progress = (minutesLogged.toFloat() / dailyGoal.coerceAtLeast(1))
+    val progressColor = if (progress >= 1f) Color(0xFF4CAF50) else MaterialTheme.colorScheme.primary
+
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(16.dp),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(
+                text = "Daily practice",
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.SemiBold
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    text = "${(progress * 100).toInt()}%",
+                    style = MaterialTheme.typography.headlineSmall,
+                    color = progressColor,
+                    fontWeight = FontWeight.Bold
+                )
+                Spacer(modifier = Modifier.weight(1f))
+                Button(onClick = onQuickPractice) {
+                    Text(text = "+1 minute")
+                }
+            }
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = "Keep a streak by practicing a little every day.",
+                style = MaterialTheme.typography.bodySmall
+            )
+        }
+    }
+}
+
+@Composable
+fun LessonCard(lesson: Lesson) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(16.dp),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(text = lesson.title, style = MaterialTheme.typography.titleMedium)
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = lesson.greek,
+                style = MaterialTheme.typography.headlineSmall,
+                fontWeight = FontWeight.Bold
+            )
+            Text(text = lesson.transliteration, style = MaterialTheme.typography.bodyMedium)
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(text = lesson.meaning, style = MaterialTheme.typography.bodyMedium)
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(text = lesson.tip, style = MaterialTheme.typography.bodySmall)
+        }
+    }
+}

--- a/android-app/app/src/main/java/com/custories/greeklearner/Theme.kt
+++ b/android-app/app/src/main/java/com/custories/greeklearner/Theme.kt
@@ -1,0 +1,35 @@
+package com.custories.greeklearner
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+
+private val LightColors = lightColorScheme(
+    primary = Color(0xFF3F51B5),
+    secondary = Color(0xFFFFB300),
+    surfaceVariant = Color(0xFFF1F2FF),
+    background = Color(0xFFF7F7FF)
+)
+
+private val DarkColors = darkColorScheme(
+    primary = Color(0xFF9FA8FF),
+    secondary = Color(0xFFFFD54F),
+    surfaceVariant = Color(0xFF1F2230),
+    background = Color(0xFF12131A)
+)
+
+@Composable
+fun GreekLearnerTheme(content: @Composable () -> Unit) {
+    val colors = if (androidx.compose.foundation.isSystemInDarkTheme()) {
+        DarkColors
+    } else {
+        LightColors
+    }
+
+    MaterialTheme(
+        colorScheme = colors,
+        content = content
+    )
+}

--- a/android-app/app/src/main/res/drawable/ic_launcher_foreground.xml
+++ b/android-app/app/src/main/res/drawable/ic_launcher_foreground.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M54,20c-18.8,0 -34,15.2 -34,34s15.2,34 34,34 34,-15.2 34,-34S72.8,20 54,20z" />
+    <path
+        android:fillColor="#3F51B5"
+        android:pathData="M54,34l14,24H40z" />
+</vector>

--- a/android-app/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/android-app/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@color/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground" />
+</adaptive-icon>

--- a/android-app/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/android-app/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@color/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground" />
+</adaptive-icon>

--- a/android-app/app/src/main/res/values/ic_launcher_background.xml
+++ b/android-app/app/src/main/res/values/ic_launcher_background.xml
@@ -1,0 +1,3 @@
+<resources>
+    <color name="ic_launcher_background">#3F51B5</color>
+</resources>

--- a/android-app/app/src/main/res/values/strings.xml
+++ b/android-app/app/src/main/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name">Greek Learner</string>
+</resources>

--- a/android-app/app/src/main/res/values/themes.xml
+++ b/android-app/app/src/main/res/values/themes.xml
@@ -1,0 +1,8 @@
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <style name="Theme.GreekLearner" parent="Theme.Material3.DayNight.NoActionBar">
+        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:navigationBarColor">@android:color/transparent</item>
+        <item name="android:windowLightStatusBar">?attr/isLightTheme</item>
+        <item name="android:windowLightNavigationBar">?attr/isLightTheme</item>
+    </style>
+</resources>

--- a/android-app/build.gradle.kts
+++ b/android-app/build.gradle.kts
@@ -1,0 +1,4 @@
+plugins {
+    alias(libs.plugins.android.application) apply false
+    alias(libs.plugins.jetbrains.kotlin.android) apply false
+}

--- a/android-app/gradle.properties
+++ b/android-app/gradle.properties
@@ -1,0 +1,3 @@
+org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+android.useAndroidX=true
+kotlin.code.style=official

--- a/android-app/gradle/libs.versions.toml
+++ b/android-app/gradle/libs.versions.toml
@@ -1,0 +1,19 @@
+[versions]
+androidGradlePlugin = "8.5.2"
+kotlin = "2.0.20"
+composeBom = "2024.09.02"
+activityCompose = "1.9.2"
+coreKtx = "1.13.1"
+
+[libraries]
+androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "coreKtx" }
+androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "activityCompose" }
+androidx-compose-bom = { module = "androidx.compose:compose-bom", version.ref = "composeBom" }
+androidx-compose-ui = { module = "androidx.compose.ui:ui" }
+androidx-compose-material3 = { module = "androidx.compose.material3:material3" }
+androidx-compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview" }
+androidx-compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling" }
+
+[plugins]
+android-application = { id = "com.android.application", version.ref = "androidGradlePlugin" }
+jetbrains-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }

--- a/android-app/settings.gradle.kts
+++ b/android-app/settings.gradle.kts
@@ -1,0 +1,18 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+rootProject.name = "GreekLearner"
+include(":app")


### PR DESCRIPTION
### Motivation
- Provide a minimal Android mobile app scaffold so the project can include a Greek learning mobile frontend.
- Ship a simple, approachable home screen with bite-size lessons and a daily practice progress affordance to validate UI direction.
- Include modern Android defaults (Jetpack Compose, Material 3, and up-to-date Gradle/Kotlin versions) to make further development straightforward.

### Description
- Add a new module at `android-app/` with Gradle configuration files including `settings.gradle.kts`, `build.gradle.kts`, `gradle/libs.versions.toml`, and `gradle.properties` to configure build tooling and dependencies.
- Implement the Compose UI and app entrypoint in `app/src/main/java/com/custories/greeklearner/MainActivity.kt`, which contains `GreekLearnerApp`, `ProgressCard`, and `LessonCard` composables with example lessons and a simple daily-goal state.
- Add theming in `app/src/main/java/com/custories/greeklearner/Theme.kt` with light/dark color schemes and wire it into the activity via `GreekLearnerTheme`.
- Include resources and manifest: `AndroidManifest.xml`, launcher icons (`ic_launcher*`), `strings.xml`, `themes.xml`, and `proguard-rules.pro` to make the module runnable in an Android environment.

### Testing
- No automated tests or CI build were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978cc94cc848323ad5c6ce0beef29b1)